### PR TITLE
Add CoreOS framework and coreosctl CLI with basic system utilities and service manager

### DIFF
--- a/System/core/coreos/CoreOS.h
+++ b/System/core/coreos/CoreOS.h
@@ -1,0 +1,7 @@
+#import "FDCompatibility.h"
+
+#import "FDSystem.h"
+#import "FDUserSession.h"
+#import "FDProcessInfo.h"
+#import "FDFileSystem.h"
+#import "FDServiceManager.h"

--- a/System/core/coreos/FDCompatibility.h
+++ b/System/core/coreos/FDCompatibility.h
@@ -1,0 +1,18 @@
+#ifndef COREOS_FD_COMPATIBILITY_H
+#define COREOS_FD_COMPATIBILITY_H
+
+/*
+ * Shared compatibility import for FreeDarwin CoreOS.
+ *
+ * Prefer Apple's Foundation when available, and fall back to FoundationKit
+ * for FreeDarwin / GNUstep-like environments.
+ */
+#if __has_include(<Foundation/Foundation.h>)
+#import <Foundation/Foundation.h>
+#elif __has_include(<FoundationKit/FoundationKit.h>)
+#import <FoundationKit/FoundationKit.h>
+#else
+#error "CoreOS requires either <Foundation/Foundation.h> or <FoundationKit/FoundationKit.h>."
+#endif
+
+#endif /* COREOS_FD_COMPATIBILITY_H */

--- a/System/core/coreos/FDFileSystem.h
+++ b/System/core/coreos/FDFileSystem.h
@@ -1,0 +1,14 @@
+#import "FDCompatibility.h"
+
+/// File system helpers shared by low-level system tools.
+@interface FDFileSystem : NSObject
+
++ (BOOL)fileExists:(NSString *)path;
+
++ (NSArray *)contentsOfDirectory:(NSString *)path;
+
++ (BOOL)createDirectory:(NSString *)path;
+
++ (BOOL)removeItem:(NSString *)path;
+
+@end

--- a/System/core/coreos/FDFileSystem.m
+++ b/System/core/coreos/FDFileSystem.m
@@ -1,0 +1,32 @@
+#import "FDFileSystem.h"
+
+@implementation FDFileSystem
+
++ (BOOL)fileExists:(NSString *)path {
+    return [[NSFileManager defaultManager] fileExistsAtPath:path];
+}
+
++ (NSArray *)contentsOfDirectory:(NSString *)path {
+    NSError *error = nil;
+    NSArray *entries = [[NSFileManager defaultManager] contentsOfDirectoryAtPath:path error:&error];
+    if (entries == nil) {
+        return [NSArray array];
+    }
+
+    return entries;
+}
+
++ (BOOL)createDirectory:(NSString *)path {
+    NSError *error = nil;
+    return [[NSFileManager defaultManager] createDirectoryAtPath:path
+                                     withIntermediateDirectories:YES
+                                                      attributes:nil
+                                                           error:&error];
+}
+
++ (BOOL)removeItem:(NSString *)path {
+    NSError *error = nil;
+    return [[NSFileManager defaultManager] removeItemAtPath:path error:&error];
+}
+
+@end

--- a/System/core/coreos/FDProcessInfo.h
+++ b/System/core/coreos/FDProcessInfo.h
@@ -1,0 +1,15 @@
+#import "FDCompatibility.h"
+
+#include <sys/types.h>
+
+/// Lightweight process inspection utilities for the current process.
+@interface FDProcessInfo : NSObject
+
++ (pid_t)processIdentifier;
++ (pid_t)parentProcessIdentifier;
+
++ (NSString *)processName;
+
++ (NSArray *)arguments;
+
+@end

--- a/System/core/coreos/FDProcessInfo.m
+++ b/System/core/coreos/FDProcessInfo.m
@@ -1,0 +1,23 @@
+#import "FDProcessInfo.h"
+
+#include <unistd.h>
+
+@implementation FDProcessInfo
+
++ (pid_t)processIdentifier {
+    return getpid();
+}
+
++ (pid_t)parentProcessIdentifier {
+    return getppid();
+}
+
++ (NSString *)processName {
+    return [[NSProcessInfo processInfo] processName];
+}
+
++ (NSArray *)arguments {
+    return [[NSProcessInfo processInfo] arguments];
+}
+
+@end

--- a/System/core/coreos/FDServiceManager.h
+++ b/System/core/coreos/FDServiceManager.h
@@ -1,0 +1,17 @@
+#import "FDCompatibility.h"
+
+/// Minimal service lifecycle helpers for CoreOS command-line usage.
+@interface FDServiceManager : NSObject
+
++ (NSString *)pidFilePathForService:(NSString *)serviceName;
+
++ (BOOL)startService:(NSString *)serviceName
+             command:(NSArray *)commandArguments
+               error:(NSError **)error;
+
++ (BOOL)stopService:(NSString *)serviceName
+              error:(NSError **)error;
+
++ (BOOL)isServiceRunning:(NSString *)serviceName;
+
+@end

--- a/System/core/coreos/FDServiceManager.m
+++ b/System/core/coreos/FDServiceManager.m
@@ -1,0 +1,123 @@
+#import "FDServiceManager.h"
+
+#include <errno.h>
+#include <signal.h>
+#include <sys/types.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+@implementation FDServiceManager
+
++ (NSString *)pidFilePathForService:(NSString *)serviceName {
+    return [@"/tmp" stringByAppendingPathComponent:[NSString stringWithFormat:@"%@.pid", serviceName]];
+}
+
++ (BOOL)startService:(NSString *)serviceName
+             command:(NSArray *)commandArguments
+               error:(NSError **)error {
+    if ([commandArguments count] == 0) {
+        if (error != NULL) {
+            NSDictionary *userInfo = [NSDictionary dictionaryWithObject:@"Missing command arguments."
+                                                                       forKey:NSLocalizedDescriptionKey];
+            *error = [NSError errorWithDomain:@"FDServiceManagerError"
+                                         code:1
+                                     userInfo:userInfo];
+        }
+        return NO;
+    }
+
+    if ([self isServiceRunning:serviceName]) {
+        if (error != NULL) {
+            NSDictionary *userInfo = [NSDictionary dictionaryWithObject:@"Service is already running."
+                                                                       forKey:NSLocalizedDescriptionKey];
+            *error = [NSError errorWithDomain:@"FDServiceManagerError"
+                                         code:2
+                                     userInfo:userInfo];
+        }
+        return NO;
+    }
+
+    pid_t child = fork();
+    if (child < 0) {
+        if (error != NULL) {
+            NSDictionary *userInfo = [NSDictionary dictionaryWithObject:@"Failed to fork service process."
+                                                                       forKey:NSLocalizedDescriptionKey];
+            *error = [NSError errorWithDomain:@"FDServiceManagerError"
+                                         code:errno
+                                     userInfo:userInfo];
+        }
+        return NO;
+    }
+
+    if (child == 0) {
+        setsid();
+
+        NSUInteger count = [commandArguments count];
+        char **argv = (char **)calloc((count + 1), sizeof(char *));
+        if (argv == NULL) {
+            _exit(127);
+        }
+
+        NSUInteger i = 0;
+        for (i = 0; i < count; i++) {
+            NSString *argument = [commandArguments objectAtIndex:i];
+            argv[i] = strdup([argument UTF8String]);
+        }
+        argv[count] = NULL;
+
+        execvp(argv[0], argv);
+        _exit(127);
+    }
+
+    NSString *pidPath = [self pidFilePathForService:serviceName];
+    NSString *pidText = [NSString stringWithFormat:@"%d\n", child];
+    return [pidText writeToFile:pidPath atomically:YES encoding:NSUTF8StringEncoding error:error];
+}
+
++ (BOOL)stopService:(NSString *)serviceName
+              error:(NSError **)error {
+    NSString *pidPath = [self pidFilePathForService:serviceName];
+    NSString *pidText = [NSString stringWithContentsOfFile:pidPath encoding:NSUTF8StringEncoding error:error];
+    if (pidText == nil) {
+        return NO;
+    }
+
+    pid_t pid = (pid_t)[pidText intValue];
+    if (kill(pid, SIGTERM) != 0 && errno != ESRCH) {
+        if (error != NULL) {
+            NSDictionary *userInfo = [NSDictionary dictionaryWithObject:@"Failed to stop service process."
+                                                                       forKey:NSLocalizedDescriptionKey];
+            *error = [NSError errorWithDomain:@"FDServiceManagerError"
+                                         code:errno
+                                     userInfo:userInfo];
+        }
+        return NO;
+    }
+
+    [[NSFileManager defaultManager] removeItemAtPath:pidPath error:NULL];
+    return YES;
+}
+
++ (BOOL)isServiceRunning:(NSString *)serviceName {
+    NSString *pidPath = [self pidFilePathForService:serviceName];
+    NSString *pidText = [NSString stringWithContentsOfFile:pidPath encoding:NSUTF8StringEncoding error:NULL];
+    if (pidText == nil) {
+        return NO;
+    }
+
+    pid_t pid = (pid_t)[pidText intValue];
+    if (pid <= 0) {
+        return NO;
+    }
+
+    if (kill(pid, 0) == 0) {
+        return YES;
+    }
+
+    if (errno == ESRCH) {
+        [[NSFileManager defaultManager] removeItemAtPath:pidPath error:NULL];
+    }
+    return NO;
+}
+
+@end

--- a/System/core/coreos/FDSystem.h
+++ b/System/core/coreos/FDSystem.h
@@ -1,0 +1,19 @@
+#import "FDCompatibility.h"
+
+@class FDUserSession;
+
+/// CoreOS framework entry point for low-level system information and paths.
+@interface FDSystem : NSObject
+
++ (NSString *)systemName;
++ (NSString *)systemVersion;
++ (NSString *)kernelVersion;
+
++ (FDUserSession *)currentUserSession;
+
++ (NSString *)rootDirectory;
++ (NSString *)applicationsDirectory;
+
++ (NSDictionary *)environment;
+
+@end

--- a/System/core/coreos/FDSystem.m
+++ b/System/core/coreos/FDSystem.m
@@ -1,0 +1,53 @@
+#import "FDSystem.h"
+
+#import <sys/utsname.h>
+
+#import "FDUserSession.h"
+#import "internal/FDInternal.h"
+
+@implementation FDSystem
+
++ (NSString *)systemName {
+    struct utsname info;
+    if (uname(&info) == 0) {
+        return [NSString stringWithUTF8String:info.sysname];
+    }
+
+    return @"FreeDarwin";
+}
+
++ (NSString *)systemVersion {
+    struct utsname info;
+    if (uname(&info) == 0) {
+        return [NSString stringWithUTF8String:info.version];
+    }
+
+    return @"0.1";
+}
+
++ (NSString *)kernelVersion {
+    struct utsname info;
+    if (uname(&info) == 0) {
+        return [NSString stringWithUTF8String:info.release];
+    }
+
+    return @"unknown";
+}
+
++ (FDUserSession *)currentUserSession {
+    return [FDUserSession currentSession];
+}
+
++ (NSString *)rootDirectory {
+    return @"/";
+}
+
++ (NSString *)applicationsDirectory {
+    return @"/Applications";
+}
+
++ (NSDictionary *)environment {
+    return FDEnvironmentDictionary();
+}
+
+@end

--- a/System/core/coreos/FDUserSession.h
+++ b/System/core/coreos/FDUserSession.h
@@ -1,0 +1,22 @@
+#import "FDCompatibility.h"
+
+#include <sys/types.h>
+
+/// Represents the active login session for the current single PocketDarwin user.
+@interface FDUserSession : NSObject {
+@private
+    NSString *_username;
+    NSString *_homeDirectory;
+    uid_t _uid;
+    gid_t _gid;
+}
+
+@property (readonly, nonatomic, copy) NSString *username;
+@property (readonly, nonatomic, copy) NSString *homeDirectory;
+@property (readonly, nonatomic) uid_t uid;
+@property (readonly, nonatomic) gid_t gid;
+
++ (FDUserSession *)currentSession;
+
+
+@end

--- a/System/core/coreos/FDUserSession.m
+++ b/System/core/coreos/FDUserSession.m
@@ -1,0 +1,86 @@
+#import "FDUserSession.h"
+
+#include <pwd.h>
+#include <unistd.h>
+#include <stdlib.h>
+
+@interface FDUserSession ()
+
+- (instancetype)initWithUsername:(NSString *)username
+                   homeDirectory:(NSString *)homeDirectory
+                             uid:(uid_t)uid
+                             gid:(gid_t)gid NS_DESIGNATED_INITIALIZER;
+
+@end
+
+@implementation FDUserSession
+
+- (instancetype)init {
+    return [[self class] currentSession];
+}
+
++ (FDUserSession *)currentSession {
+    uid_t uid = getuid();
+    struct passwd *entry = getpwuid(uid);
+
+    NSString *username = @"mobile";
+    gid_t gid = getgid();
+
+    if (entry != NULL) {
+        if (entry->pw_name != NULL) {
+            username = [NSString stringWithUTF8String:entry->pw_name];
+        }
+        gid = entry->pw_gid;
+    }
+
+    const char *homeValue = getenv("HOME");
+    NSString *homeDirectory = nil;
+
+    if (homeValue != NULL) {
+        homeDirectory = [NSString stringWithUTF8String:homeValue];
+    } else if (entry != NULL && entry->pw_dir != NULL) {
+        homeDirectory = [NSString stringWithUTF8String:entry->pw_dir];
+    }
+
+    if (homeDirectory == nil || [homeDirectory length] == 0) {
+        homeDirectory = @"/";
+    }
+
+    return [[self alloc] initWithUsername:username
+                            homeDirectory:homeDirectory
+                                      uid:uid
+                                      gid:gid];
+}
+
+- (instancetype)initWithUsername:(NSString *)username
+                   homeDirectory:(NSString *)homeDirectory
+                             uid:(uid_t)uid
+                             gid:(gid_t)gid {
+    self = [super init];
+    if (self != nil) {
+        _username = [username copy];
+        _homeDirectory = [homeDirectory copy];
+        _uid = uid;
+        _gid = gid;
+    }
+
+    return self;
+}
+
+- (NSString *)username {
+    return _username;
+}
+
+- (NSString *)homeDirectory {
+    return _homeDirectory;
+}
+
+- (uid_t)uid {
+    return _uid;
+}
+
+- (gid_t)gid {
+    return _gid;
+}
+
+@end

--- a/System/core/coreos/GNUmakefile
+++ b/System/core/coreos/GNUmakefile
@@ -1,17 +1,37 @@
 include $(GNUSTEP_MAKEFILES)/common.make
 
-# The name of your executable
-TOOL_NAME = CoreOS
+LIBRARY_NAME = CoreOS
 
-# The list of Objective-C source files
-CoreOS_OBJC_FILES = main.m \
-					FDSystem.m \
-					FDUser.m \
-					FDUserSession.m \
-					FDUtsname.m \
-					FDTuxedo.m \
-					SystemTypeIdner.m \
-					libSystemGrepper.m
+CoreOS_OBJC_FILES = \
+    FDSystem.m \
+    FDUserSession.m \
+    FDProcessInfo.m \
+    FDFileSystem.m \
+    FDServiceManager.m
 
-# Include the rules for command-line tools
+CoreOS_HEADER_FILES = \
+    CoreOS.h \
+    FDCompatibility.h \
+    FDSystem.h \
+    FDUserSession.h \
+    FDProcessInfo.h \
+    FDFileSystem.h \
+    FDServiceManager.h
+
+CoreOS_INSTALL_DIR = $(GNUSTEP_LOCAL_LIBRARY)/Frameworks
+
+include $(GNUSTEP_MAKEFILES)/library.make
+
+TOOL_NAME = coreosctl
+
+coreosctl_OBJC_FILES = \
+    main.m \
+    FDSystem.m \
+    FDUserSession.m \
+    FDProcessInfo.m \
+    FDFileSystem.m \
+    FDServiceManager.m
+
+coreosctl_TOOL_LIBS = -lobjc -lgnustep-base
+
 include $(GNUSTEP_MAKEFILES)/tool.make

--- a/System/core/coreos/internal/FDInternal.h
+++ b/System/core/coreos/internal/FDInternal.h
@@ -1,0 +1,31 @@
+#import "FDCompatibility.h"
+
+/// Shared internal helpers used by CoreOS implementation files.
+static inline NSDictionary *FDEnvironmentDictionary(void) {
+    NSMutableDictionary *environment = [NSMutableDictionary dictionary];
+
+    extern char **environ;
+
+    if (environ == NULL) {
+        return environment;
+    }
+
+    char **entry = environ;
+    for (; *entry != NULL; entry++) {
+        NSString *line = [NSString stringWithUTF8String:*entry];
+        NSRange separator = [line rangeOfString:@"="];
+
+        if (separator.location == NSNotFound) {
+            continue;
+        }
+
+        NSString *key = [line substringToIndex:separator.location];
+        NSString *value = [line substringFromIndex:(separator.location + 1)];
+
+        if ([key length] > 0) {
+            [environment setObject:value forKey:key];
+        }
+    }
+
+    return environment;
+}

--- a/System/core/coreos/main.m
+++ b/System/core/coreos/main.m
@@ -1,19 +1,94 @@
-/* 
-        This CoreOS userland implementations relies on
-        GNUStep's FoundationKit (works as well with Apple's FoundationKit).
+#import "CoreOS.h"
 
-        If you don't have an Objective-C Compiler read the docs for more info.
+static void FDPrintUsage(void) {
+    fprintf(stderr,
+            "Usage:\n"
+            "  coreosctl info\n"
+            "  coreosctl service start <name> <command> [args...]\n"
+            "  coreosctl service stop <name>\n"
+            "  coreosctl service status <name>\n");
+}
 
-*/
+int main(int argc, const char *argv[]) {
+    NSAutoreleasePool *pool = [[NSAutoreleasePool alloc] init];
+    int exitCode = 0;
 
+    if (argc < 2) {
+        FDPrintUsage();
+        exitCode = 1;
+        goto cleanup;
+    }
 
-#define _GNU_SOURCE
+    NSString *action = [NSString stringWithUTF8String:argv[1]];
 
-#import <Foundation/Foundation.h>
-#include <Foundation/NSObjCRuntime.h>
-#import "include/SystemHeader.h"
+    if ([action isEqualToString:@"info"]) {
+        NSLog(@"System: %@ %@ (kernel %@)", [FDSystem systemName], [FDSystem systemVersion], [FDSystem kernelVersion]);
+        exitCode = 0;
+        goto cleanup;
+    }
 
-int main() {
-    NSLog(@"CoreOS booting on %@", [FDSystemTypeIdentifier currentPlatformName]);
-    return 0;
+    if (![action isEqualToString:@"service"]) {
+        FDPrintUsage();
+        exitCode = 1;
+        goto cleanup;
+    }
+
+    if (argc < 4) {
+        FDPrintUsage();
+        exitCode = 1;
+        goto cleanup;
+    }
+
+    NSString *verb = [NSString stringWithUTF8String:argv[2]];
+    NSString *serviceName = [NSString stringWithUTF8String:argv[3]];
+
+    if ([verb isEqualToString:@"status"]) {
+        BOOL running = [FDServiceManager isServiceRunning:serviceName];
+        printf("%s\n", running ? "running" : "stopped");
+        exitCode = running ? 0 : 3;
+        goto cleanup;
+    }
+
+    if ([verb isEqualToString:@"stop"]) {
+        NSError *error = nil;
+        if (![FDServiceManager stopService:serviceName error:&error]) {
+            NSLog(@"Failed to stop %@: %@", serviceName, [error localizedDescription]);
+            exitCode = 2;
+            goto cleanup;
+        }
+        NSLog(@"Stopped service %@", serviceName);
+        exitCode = 0;
+        goto cleanup;
+    }
+
+    if ([verb isEqualToString:@"start"]) {
+        if (argc < 5) {
+            FDPrintUsage();
+            exitCode = 1;
+            goto cleanup;
+        }
+
+        NSMutableArray *command = [NSMutableArray array];
+        int i = 0;
+        for (i = 4; i < argc; i++) {
+            [command addObject:[NSString stringWithUTF8String:argv[i]]];
+        }
+
+        NSError *error = nil;
+        if (![FDServiceManager startService:serviceName command:command error:&error]) {
+            NSLog(@"Failed to start %@: %@", serviceName, [error localizedDescription]);
+            exitCode = 2;
+            goto cleanup;
+        }
+        NSLog(@"Started service %@", serviceName);
+        exitCode = 0;
+        goto cleanup;
+    }
+
+    FDPrintUsage();
+    exitCode = 1;
+
+cleanup:
+    [pool drain];
+    return exitCode;
 }


### PR DESCRIPTION
### Motivation

- Provide a small CoreOS framework containing common low-level system utilities for PocketDarwin/FreeDarwin environments. 
- Expose reusable helpers for process, user session, filesystem, environment and minimal service lifecycle management. 
- Add a small command-line tool `coreosctl` to query system info and manage simple pidfile-backed services.

### Description

- Add `FDCompatibility.h` to choose Apple's `Foundation` or GNUstep's `FoundationKit` and an umbrella `CoreOS.h` that exports the framework headers. 
- Implement `FDSystem` (system name/version/kernel, root/app directories, environment via `internal/FDInternal.h`) and `FDUserSession` (current login session info using `getpwuid`/`getenv`). 
- Add `FDProcessInfo` (pid, ppid, process name and args) and `FDFileSystem` (thin `NSFileManager` wrappers for common file operations). 
- Implement `FDServiceManager` to start/stop/check services using `fork`/`execvp`, pidfiles under `/tmp/<service>.pid`, and signal-based checks. 
- Add `internal/FDInternal.h` to build an environment dictionary from `environ`. 
- Replace previous `main.m` with a new CLI (`coreosctl`) supporting `info` and `service (start|stop|status)` subcommands and update `GNUmakefile` to build both the `CoreOS` framework and the `coreosctl` tool.

### Testing

- Built the project using the provided `GNUmakefile` with `make` to produce the `CoreOS` library and `coreosctl` tool, and the build completed successfully. 
- No automated unit tests were added in this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ac15af1dd88330bb60fe39a0452647)