### PR TITLE
Add system-bundle builder and iPhoneOS2.0 cross-compile support

### DIFF
--- a/BuildSystem/README.md
+++ b/BuildSystem/README.md
@@ -1,25 +1,51 @@
 # PocketDarwin Build System (Swift)
 
-This is a standalone Swift script that orchestrates project builds across platforms.
+This is a standalone Swift script that orchestrates project builds across platforms and can now generate portable `.System` bundles.
 
 Usage:
-```
+```sh
 ./BuildSystem/pdbuild.swift <command>
 ```
 
 Commands:
 - `interlude`        Build the interlude loader
 - `sdk-validate`     Validate the SDK sysroot
-- `sdk-populate`     Populate the SDK sysroot (requires --headers and --libs)
+- `sdk-populate`     Populate the SDK sysroot (requires `--headers` and `--libs`)
 - `installer-build`  Build the macOS installer app (macOS only)
 - `installer-dmg`    Build the macOS installer DMG (macOS only)
+- `system-bundle`    Build System components and emit a `.System` bundle with metadata
 - `all`              Run interlude + sdk-validate (+ installer on macOS)
 
-Examples:
+## System bundle output naming
+
+`system-bundle` emits a bundle named with:
+- current git branch,
+- UTC build date/time (`yyyyMMdd-HHmmss`),
+- random codename (`Adjective-Noun`)
+
+Example:
+
+```text
+PocketDarwin-main-20260307-120501-Aurora-Falcon.System
 ```
-./BuildSystem/pdbuild.swift interlude
-./BuildSystem/pdbuild.swift sdk-validate
-./BuildSystem/pdbuild.swift sdk-populate --headers /path/to/headers --libs /path/to/libs
-./BuildSystem/pdbuild.swift installer-build --config Release --derived /tmp/PDDerivedData
-./BuildSystem/pdbuild.swift installer-dmg
+
+Inside the output bundle:
+- `Contents/Info.plist` includes the same metadata
+- payload is arranged under `Contents/System/{Applications,Libraries,Services,Programs}`
+
+## iPhoneOS 2.0 cross-compiling
+
+`system-bundle` supports using an iPhoneOS 2.0 sysroot for cross-compiling make-based components.
+
+Examples:
+
+```sh
+# Explicit SDK path
+./BuildSystem/pdbuild.swift system-bundle --sdk-root /path/to/iPhoneOS2.0.sdk
+
+# Repository shortcut (Developer/SDKs/iPhoneOS2.0.sdk)
+./BuildSystem/pdbuild.swift system-bundle --iphoneos2-sdk
+
+# Custom output directory
+./BuildSystem/pdbuild.swift system-bundle --iphoneos2-sdk --output-dir build/releases
 ```

--- a/BuildSystem/pdbuild.swift
+++ b/BuildSystem/pdbuild.swift
@@ -1,3 +1,4 @@
+#!/usr/bin/env swift
 import Foundation
 
 struct Shell {
@@ -18,7 +19,6 @@ struct Shell {
         process.standardError = pipe
 
         try process.run()
-
         let handle = pipe.fileHandleForReading
         while true {
             let data = handle.availableData
@@ -30,6 +30,27 @@ struct Shell {
 
         process.waitUntilExit()
         return process.terminationStatus
+    }
+
+    static func capture(_ command: String, _ args: [String] = []) -> String? {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: command)
+        process.arguments = args
+
+        let pipe = Pipe()
+        process.standardOutput = pipe
+        process.standardError = Pipe()
+
+        do {
+            try process.run()
+        } catch {
+            return nil
+        }
+
+        process.waitUntilExit()
+        guard process.terminationStatus == 0 else { return nil }
+        let data = pipe.fileHandleForReading.readDataToEndOfFile()
+        return String(data: data, encoding: .utf8)?.trimmingCharacters(in: .whitespacesAndNewlines)
     }
 
     static func which(_ name: String) -> String? {
@@ -50,10 +71,13 @@ struct Paths {
         return URL(fileURLWithPath: cwd)
     }()
 
-//    static let interludeDir = root.appendingPathComponent("System/Boot/interlude")
+    static let interludeDir = root.appendingPathComponent("System/Boot/interlude")
     static let sdkScripts = root.appendingPathComponent("Developer/SDKs/scripts")
     static let installerProject = root.appendingPathComponent("Platform/macOS/Install PocketDarwin/Install PocketDarwin.xcodeproj")
     static let dmgScript = root.appendingPathComponent("scripts/make_dmg.sh")
+    static let systemDir = root.appendingPathComponent("System")
+    static let distDir = root.appendingPathComponent("build/dist")
+    static let defaultIPhoneOS20SDK = root.appendingPathComponent("Developer/SDKs/iPhoneOS2.0.sdk")
 }
 
 func usage() {
@@ -69,13 +93,17 @@ Commands:
   sdk-populate         Populate SDK sysroot (requires --headers and --libs)
   installer-build      Build macOS installer app (uses xcodebuild on macOS)
   installer-dmg        Build macOS installer DMG (uses scripts/make_dmg.sh)
+  system-bundle        Build apps/libs/services/programs and emit a .System bundle
   all                  Run interlude + sdk-validate (and installer on macOS)
 
 Options:
-  --headers <path>     Headers directory for sdk-populate
-  --libs <path>        Libs directory for sdk-populate
-  --derived <path>     DerivedData path for installer build
-  --config <Debug|Release>  Build configuration for installer (default Release)
+  --headers <path>               Headers directory for sdk-populate
+  --libs <path>                  Libs directory for sdk-populate
+  --derived <path>               DerivedData path for installer build
+  --config <Debug|Release>       Build configuration for installer (default Release)
+  --sdk-root <path>              Sysroot used for cross-compiling system-bundle
+  --iphoneos2-sdk                Shortcut for --sdk-root Developer/SDKs/iPhoneOS2.0.sdk
+  --output-dir <path>            Output directory for generated .System bundle (default build/dist)
 """)
 }
 
@@ -87,6 +115,7 @@ func requireDir(_ path: String) throws {
 }
 
 func runInterlude() throws {
+    try requireDir(Paths.interludeDir.path)
     let make = Shell.which("make") ?? "/usr/bin/make"
     let status = try Shell.run(make, ["-C", Paths.interludeDir.path])
     if status != 0 { throw NSError(domain: "pdbuild", code: 2, userInfo: [NSLocalizedDescriptionKey: "interlude build failed"]) }
@@ -133,8 +162,164 @@ func installerDMG() throws {
     #endif
 }
 
+func randomCodename() -> String {
+    let adjectives = ["Aurora", "Crimson", "Nimbus", "Solar", "Velvet", "Copper", "Lunar", "Silent", "Rapid", "Frost"]
+    let nouns = ["Otter", "Falcon", "Harbor", "Comet", "Cedar", "Wave", "Forge", "Echo", "Quartz", "Signal"]
+    return "\(adjectives.randomElement() ?? "Pocket")-\(nouns.randomElement() ?? "Darwin")"
+}
+
+func currentBranchName() -> String {
+    guard let git = Shell.which("git"),
+          let branch = Shell.capture(git, ["rev-parse", "--abbrev-ref", "HEAD"]),
+          !branch.isEmpty else {
+        return "detached"
+    }
+
+    let allowed = CharacterSet.alphanumerics.union(CharacterSet(charactersIn: "-_."))
+    return String(branch.unicodeScalars.map { allowed.contains($0) ? Character($0) : "-" })
+}
+
+func timestamp() -> String {
+    let formatter = DateFormatter()
+    formatter.dateFormat = "yyyyMMdd-HHmmss"
+    formatter.locale = Locale(identifier: "en_US_POSIX")
+    formatter.timeZone = TimeZone(secondsFromGMT: 0)
+    return formatter.string(from: Date())
+}
+
+func crossCompileEnvironment(sdkRoot: String?) -> [String: String] {
+    guard let sdkRoot = sdkRoot else { return [:] }
+
+    let isysrootFlags = "-isysroot \(sdkRoot) -miphoneos-version-min=2.0"
+    var env: [String: String] = [
+        "SDKROOT": sdkRoot,
+        "IPHONEOS_DEPLOYMENT_TARGET": "2.0",
+        "CFLAGS": isysrootFlags,
+        "CXXFLAGS": isysrootFlags,
+        "OBJCFLAGS": isysrootFlags,
+        "LDFLAGS": isysrootFlags
+    ]
+
+    if let cc = Shell.which("clang") {
+        env["CC"] = cc
+    }
+    if let cxx = Shell.which("clang++") {
+        env["CXX"] = cxx
+    }
+
+    return env
+}
+
+func buildWithMakeIfPresent(in directory: URL, env: [String: String]) throws -> Bool {
+    let makefile = directory.appendingPathComponent("Makefile")
+    let gnumakefile = directory.appendingPathComponent("GNUmakefile")
+    guard FileManager.default.fileExists(atPath: makefile.path) || FileManager.default.fileExists(atPath: gnumakefile.path) else {
+        return true
+    }
+
+    let make = Shell.which("make") ?? "/usr/bin/make"
+    let status = try Shell.run(make, ["-C", directory.path], env: env)
+    if status != 0 {
+        return false
+    }
+    return true
+}
+
+func buildTargets(in root: URL, env: [String: String]) throws -> [String] {
+    guard let entries = try? FileManager.default.contentsOfDirectory(at: root, includingPropertiesForKeys: nil, options: [.skipsHiddenFiles]) else {
+        return []
+    }
+    var failed: [String] = []
+    for entry in entries where entry.hasDirectoryPath {
+        let ok = try buildWithMakeIfPresent(in: entry, env: env)
+        if !ok { failed.append(entry.path) }
+    }
+    return failed
+}
+
+func writeBundleInfoPlist(to plistPath: URL, bundleName: String, branch: String, codename: String, builtAt: String) throws {
+    let plist: [String: Any] = [
+        "CFBundleName": "PocketDarwin System Bundle",
+        "CFBundleIdentifier": "org.pocketdarwin.systembundle",
+        "CFBundleVersion": builtAt,
+        "PDSystemBundleName": bundleName,
+        "PDBuildBranch": branch,
+        "PDBuildTimestamp": builtAt,
+        "PDBuildCodename": codename,
+        "PDBuildSDK": "iPhoneOS2.0"
+    ]
+
+    let data = try PropertyListSerialization.data(fromPropertyList: plist, format: .xml, options: 0)
+    try data.write(to: plistPath)
+}
+
+func copyIfExists(from src: URL, to dst: URL) throws {
+    if FileManager.default.fileExists(atPath: src.path) {
+        try FileManager.default.createDirectory(at: dst.deletingLastPathComponent(), withIntermediateDirectories: true)
+        if FileManager.default.fileExists(atPath: dst.path) {
+            try FileManager.default.removeItem(at: dst)
+        }
+        try FileManager.default.copyItem(at: src, to: dst)
+    }
+}
+
+func buildSystemBundle(sdkRoot: String?, outputDir: String) throws {
+    let fm = FileManager.default
+    let bundleBranch = currentBranchName()
+    let bundleTimestamp = timestamp()
+    let codename = randomCodename()
+    let bundleName = "PocketDarwin-\(bundleBranch)-\(bundleTimestamp)-\(codename).System"
+
+    let outputURL = URL(fileURLWithPath: outputDir, relativeTo: Paths.root).standardizedFileURL
+    try fm.createDirectory(at: outputURL, withIntermediateDirectories: true)
+
+    let bundleURL = outputURL.appendingPathComponent(bundleName)
+    if fm.fileExists(atPath: bundleURL.path) {
+        try fm.removeItem(at: bundleURL)
+    }
+
+    let contentsURL = bundleURL.appendingPathComponent("Contents")
+    let systemPayloadURL = contentsURL.appendingPathComponent("System")
+    let appsURL = systemPayloadURL.appendingPathComponent("Applications")
+    let frameworksURL = systemPayloadURL.appendingPathComponent("Libraries")
+    let servicesURL = systemPayloadURL.appendingPathComponent("Services")
+    let programsURL = systemPayloadURL.appendingPathComponent("Programs")
+
+    try fm.createDirectory(at: appsURL, withIntermediateDirectories: true)
+    try fm.createDirectory(at: frameworksURL, withIntermediateDirectories: true)
+    try fm.createDirectory(at: servicesURL, withIntermediateDirectories: true)
+    try fm.createDirectory(at: programsURL, withIntermediateDirectories: true)
+
+    let env = crossCompileEnvironment(sdkRoot: sdkRoot)
+    print("Building applications, libraries, services, and programs...")
+    var failures: [String] = []
+    failures += try buildTargets(in: Paths.systemDir.appendingPathComponent("Applications"), env: env)
+    failures += try buildTargets(in: Paths.systemDir.appendingPathComponent("Frameworks"), env: env)
+    failures += try buildTargets(in: Paths.systemDir.appendingPathComponent("Services"), env: env)
+    failures += try buildTargets(in: Paths.systemDir.appendingPathComponent("Programs"), env: env)
+
+    try copyIfExists(from: Paths.systemDir.appendingPathComponent("Applications"), to: appsURL)
+    try copyIfExists(from: Paths.systemDir.appendingPathComponent("Frameworks"), to: frameworksURL)
+    try copyIfExists(from: Paths.systemDir.appendingPathComponent("Services"), to: servicesURL)
+    try copyIfExists(from: Paths.systemDir.appendingPathComponent("Programs"), to: programsURL)
+
+    try writeBundleInfoPlist(
+        to: contentsURL.appendingPathComponent("Info.plist"),
+        bundleName: bundleName,
+        branch: bundleBranch,
+        codename: codename,
+        builtAt: bundleTimestamp
+    )
+
+    print("Generated: \(bundleURL.path)")
+    if !failures.isEmpty {
+        print("Warning: some targets failed to build and were packaged from source state:")
+        for failure in failures { print(" - \(failure)") }
+    }
+}
+
 func main() throws {
-    var args = CommandLine.arguments
+    let args = CommandLine.arguments
     guard args.count >= 2 else {
         usage()
         return
@@ -163,6 +348,16 @@ func main() throws {
         try installerBuild(config: config, derived: derived)
     case "installer-dmg":
         try installerDMG()
+    case "system-bundle":
+        var sdkRoot = value(after: "--sdk-root")
+        if args.contains("--iphoneos2-sdk") {
+            sdkRoot = Paths.defaultIPhoneOS20SDK.path
+        }
+        if let sdkRoot = sdkRoot {
+            try requireDir(sdkRoot)
+        }
+        let outputDir = value(after: "--output-dir") ?? Paths.distDir.path
+        try buildSystemBundle(sdkRoot: sdkRoot, outputDir: outputDir)
     case "all":
         try runInterlude()
         try sdkValidate()
@@ -177,4 +372,9 @@ func main() throws {
     }
 }
 
-try main()
+do {
+    try main()
+} catch {
+    fputs("error: \(error.localizedDescription)\n", stderr)
+    exit(1)
+}

--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,7 @@ PDPACK_DIR := Tools/pdpack
 ISTDLIB_DIR := istdlib
 SYSTEM_DIR := System
 SYSTEM_TARGET ?= harpia
+SYSTEM_BUNDLE_FLAGS ?=
 
 .PHONY: help
 help:
@@ -46,7 +47,8 @@ help:
 		'  rust                 Build all Rust crates' \
 		'  rust-check           cargo check for Rust crates' \
 		'  rust-test            cargo test for Rust crates' \
-		'  system               Build System target (SYSTEM_TARGET=<name>, default harpia)'
+		'  system               Build System target (SYSTEM_TARGET=<name>, default harpia)' \
+		'  system-bundle        Build and package .System bundle (uses BuildSystem/pdbuild.swift)'
 
 .PHONY: build
 build: android rust
@@ -125,6 +127,11 @@ rust-clean:
 .PHONY: system
 system:
 	@$(MAKE) -C $(SYSTEM_DIR) $(SYSTEM_TARGET)
+
+
+.PHONY: system-bundle
+system-bundle:
+	@./BuildSystem/pdbuild.swift system-bundle $(SYSTEM_BUNDLE_FLAGS)
 
 .PHONY: system-clean
 system-clean:


### PR DESCRIPTION
### Motivation
- Provide a single build pipeline that assembles applications, libraries, services, and programs into a portable `.System` bundle for distribution. 
- Embed reproducible build metadata (git branch, UTC timestamp, random codename) in the bundle name and `Info.plist` for easier tracing of outputs. 
- Allow cross-compiling legacy make-based components against an `iPhoneOS2.0` sysroot and perform best-effort packaging when some legacy targets fail.

### Description
- Implemented a `system-bundle` command in `BuildSystem/pdbuild.swift` that builds make-based components under `System/{Applications,Frameworks,Services,Programs}`, arranges payload under `Contents/System/...`, and generates `Contents/Info.plist`. 
- Named output bundles using the pattern `PocketDarwin-<branch>-<YYYYMMDD-HHMMSS>-<Adjective-Noun>.System` and recorded `PDBuildBranch`, `PDBuildTimestamp`, `PDBuildCodename`, and `PDBuildSDK` in the plist. 
- Added optional cross-compile support via `--sdk-root <path>` and a repository shortcut `--iphoneos2-sdk` (points to `Developer/SDKs/iPhoneOS2.0.sdk`), injecting `SDKROOT`, `IPHONEOS_DEPLOYMENT_TARGET`, `CFLAGS/CXXFLAGS/OBJCFLAGS/LDFLAGS` and `CC/CXX` where available. 
- Made builds resilient: `pdbuild` attempts to `make` per-subdirectory, collects failures, continues packaging, and prints warnings for failed subprojects; added a top-level `make system-bundle` target (configurable via `SYSTEM_BUNDLE_FLAGS`) and updated `BuildSystem/README.md` with usage and examples.

### Testing
- Ran `./BuildSystem/pdbuild.swift --help` which printed updated command and option list successfully. 
- Ran `make help` which included the new `system-bundle` target in the help text successfully. 
- Executed `./BuildSystem/pdbuild.swift system-bundle --output-dir build/dist-test` which completed, generated a `.System` bundle in `build/dist-test`, and surfaced legacy component make failures as warnings (bundle generation still succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ac26314e888330bb2ddea36b7c9b59)