### PR TITLE
Improve README with clearer onboarding, playful tone, and repo image

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,37 +1,101 @@
 <div align="center">
-  <img src="logo.png" alt="PocketDarwin Logo" width="240" />
+  <img src="logo.png" alt="PocketDarwin logo" width="180" />
   <h1>PocketDarwin</h1>
-  <p>I'm the crazy guy who's gonna clone iOS! — OakyMacintosh</p>
+  <p><em>"I’m the crazy guy who’s gonna clone iOS!" — OakyMacintosh</em></p>
 </div>
 
-## What This Repo Is
-PocketDarwin is an Darwin port for Android hardware.
+<div align="center">
+  <img src="iphone-sdk-4.png" alt="PocketDarwin iPhone SDK preview" width="760" />
+</div>
 
->[!NEW] Discord server now available on https://discord.gg/bthwXwh8vP
+PocketDarwin is an experimental, open-source effort to bring a Darwin/iPhone-OS-style software stack to non-Apple hardware (especially Android devices).
 
-## Installation instructions
+In plain words: this repo is where people tinker with kernels, frameworks, apps, and SDK tooling to recreate the classic iPhone-era development/runtime experience.
 
->[!NOTE] PocketDarwin will never ships pre-built linux interludes!! Only system bundles are released.
+---
 
-```sh
-# build the xnu kernel
-$ cd System/darwinKernel/xnu-arm
-$ make TARGET_CONFIGS="debug arm ARMPBA8"
-# build the interlude linux kernel
-# you will need to get your device's android linux kernel.
-# for example: android_kernel_moto_msm9816
-$ cd System/Boot/linuxTemp/<the device kernel dir>
-$ cp ../configs/<device codename>/.config .config
-$ ARCH="arm" make
-# create the System bundle
-$ cd System/SystemBundle
-# for macOS
-$ make darwinApp
-# for linux
-$ make linuxapp
-$ ./dist/pdbundle -kernel ../darwinKernel/xnu-arm/BUILD/DEBUG_ARM/kernel -sysroot $(./pdbundle -makesysroot -s 30G) -relname PocketDarwin.System -buildsys -buildframeworks="../../Frameworks"
-```
+## ✨ What is this project trying to do?
 
-## Supported devices
-- harpia (Moto G4 Play, 2016, Linux kernel 3.10) **official development device**
-- Any android device thats aarch64 and has the linux kernel source tree publicaly available
+PocketDarwin is aiming to assemble a full "mini ecosystem":
+
+- **System layer**: boot and low-level platform bits.
+- **Framework layer**: Objective-C-friendly frameworks and glue.
+- **Application layer**: SpringBoard-like UI and bundled apps.
+- **Developer layer**: SDK/toolchain pieces for building software against PocketDarwin.
+- **Android bridge work**: experiments that let parts of this stack run in Android environments.
+
+This is an active hacking project, not a finished product.
+
+---
+
+## 🧭 Repo map (where things live)
+
+If you’re new, start here:
+
+- `System/` → boot/platform code and system apps (including SpringBoard work)
+- `Frameworks/` → core frameworks + build helpers (`MakeKit`, `TerminalKit`, etc.)
+- `Developer/` → SDKs, toolchains, and scripts for developer workflows
+- `BuildSystem/` → build orchestration pieces
+- `Android/` → Android-side experiments/integration projects
+- `Tools/` → utility tools used by the project
+
+---
+
+## 🚀 Quick start (pick your adventure)
+
+### 1) I just want to understand the build system
+Read:
+
+- `BuildSystem/README.md`
+
+### 2) I want SDK/toolchain details
+Read:
+
+- `Developer/SDKs/README.md`
+- `Developer/common-3.0-sdk/README.md`
+
+### 3) I want to poke around SpringBoard/app code
+Start in:
+
+- `System/Applications/springboard/`
+
+### 4) I want to hack utilities
+Start in:
+
+- `Tools/pdpack/`
+
+---
+
+## 📦 Current status
+
+PocketDarwin is **work-in-progress** and heavily experimental.
+Expect rough edges, incomplete components, and frequent changes.
+
+> [!NOTE]
+> PocketDarwin does not aim to provide generic prebuilt Linux "interludes" for every setup.
+> You should expect source-based setup/build workflows.
+
+> [!TIP]
+> Join the community Discord: https://discord.gg/bthwXwh8vP
+
+---
+
+## 📱 Supported hardware (today)
+
+- **harpia** (Moto G4 Play, 2016, Linux kernel 3.10) — official development device
+- Potentially other **aarch64 Android devices** with publicly available kernel source trees
+
+---
+
+## 🤝 Contributing
+
+Contributions are welcome — code, docs, testing, bug reports, and wild ideas.
+
+A good first contribution is improving docs for one subdirectory you touched.
+If you had to reverse-engineer how something works, write it down for the next person.
+
+---
+
+## ⚖️ License
+
+See `LICENSE` for project licensing.

--- a/README.md
+++ b/README.md
@@ -46,23 +46,23 @@ If you’re new, start here:
 ### 1) I just want to understand the build system
 Read:
 
-- `BuildSystem/README.md`
+- [`BuildSystem/README.md`](BuildSystem/README.md)
 
 ### 2) I want SDK/toolchain details
 Read:
 
-- `Developer/SDKs/README.md`
-- `Developer/common-3.0-sdk/README.md`
+- [`Developer/SDKs/README.md`](Developer/SDKs/README.md)
+- [`Developer/common-3.0-sdk/README.md`](Developer/common-3.0-sdk/README.md)
 
 ### 3) I want to poke around SpringBoard/app code
 Start in:
 
-- `System/Applications/springboard/`
+- [`System/Applications/springboard/`](System/Applications/springboard/)
 
 ### 4) I want to hack utilities
 Start in:
 
-- `Tools/pdpack/`
+- [`Tools/pdpack/`](Tools/pdpack/)
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -32,12 +32,12 @@ This is an active hacking project, not a finished product.
 
 If you’re new, start here:
 
-- `System/` → boot/platform code and system apps (including SpringBoard work)
-- `Frameworks/` → core frameworks + build helpers (`MakeKit`, `TerminalKit`, etc.)
-- `Developer/` → SDKs, toolchains, and scripts for developer workflows
-- `BuildSystem/` → build orchestration pieces
-- `Android/` → Android-side experiments/integration projects
-- `Tools/` → utility tools used by the project
+- [`System/`](System/) → boot/platform code and system apps (including SpringBoard work)
+- [`Frameworks/`](Frameworks/) → core frameworks + build helpers (`MakeKit`, `TerminalKit`, etc.)
+- [`Developer/`](Developer/) → SDKs, toolchains, and scripts for developer workflows
+- [`BuildSystem/`](BuildSystem/) → build orchestration pieces
+- [`Android/`](Android/) → Android-side experiments/integration projects
+- [`Tools/`](Tools/) → utility tools used by the project
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -98,4 +98,4 @@ If you had to reverse-engineer how something works, write it down for the next p
 
 ## ⚖️ License
 
-See `LICENSE` for project licensing.
+See [`LICENSE`](LICENSE) for project licensing.


### PR DESCRIPTION
### Motivation
- Make the root `README.md` self-explaining and newcomer-friendly while keeping a playful voice. 
- Surface the repository image and visual preview so readers immediately see the project context. 
- Reduce onboarding friction by pointing people to maintained subdirectory docs instead of a long, potentially stale build block. 

### Description
- Rewrote the root `README.md` with a clearer intro, structured headings, and a playful tagline. 
- Adjusted logo sizing and styling and added the existing `iphone-sdk-4.png` image prominently near the top. 
- Removed the long inline build command block and replaced it with a compact “Quick start” that links to `BuildSystem/`, `Developer/SDKs/`, and other focused docs. 
- Added a concise repo map, current status notes, supported hardware section, and contribution guidance to help new contributors find relevant places to start. 

### Testing
- Ran `git diff --check` to confirm there are no whitespace or patch-format issues and it succeeded. 
- Verified repository status with `git status --short` to confirm the `README.md` change was present and it returned the expected modified file.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ac2bb73c248330af40befd8adea6ff)